### PR TITLE
promote Ziyi-Tan as new committer of curve community

### DIFF
--- a/teams/Curve/team.json
+++ b/teams/Curve/team.json
@@ -21,6 +21,7 @@
         "Xinlong-Chen"
         "baytan0720"
         "201341"
+        "Ziy1-Tan"
     ],
     
     "reviewers": [


### PR DESCRIPTION
@Ziy1-Tan has been a contributer since [Feb 10, 2023](https://github.com/opencurve/curve/pull/2206), and he has been very actively [contributing](https://github.com/opencurve/curve/pulls?q=is%3Apr+author%3AZiy1-Tan) to the project.

So I'd like to promote @Ziy1-Tan  to a Committer.

Needs explicit LGTM from @Ziy1-Tan  and majority of the Curve Committers, according to [GOVERNANCE.md](https://github.com/opencurve/community/blob/master/GOVERNANCE.md):
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/15689619/211236417-eb405af2-7f0c-48b3-9012-cf41f5ab6bc7.png">

- [x] Wangpan
- [ ] ilixiaocui
- [x] Wine93
- [x] wuhongsong
- [x] Cyber-SiKu

I'd also like to get a few LGTMs from the Core Committers too. (not necessary)

This PR will remain open for 6 days.