### PR TITLE
promote baytan0720 as new committer of curve community

### DIFF
--- a/teams/Curve/team.json
+++ b/teams/Curve/team.json
@@ -19,6 +19,7 @@
         "Wine93",
         "fansehep",
         "Xinlong-Chen"
+        "baytan0720"
     ],
     
     "reviewers": [


### PR DESCRIPTION
@baytan0720 has been a contributer since [May 5, 2023](https://github.com/opencurve/curve/pull/2434), and he has been very actively [contributing](https://github.com/opencurve/curve/pulls?q=is%3Apr+author%3Abaytan0720) to the project.

So I'd like to promote @baytan0720  to a Committer.

Needs explicit LGTM from @baytan0720  and majority of the Curve Committers, according to [GOVERNANCE.md](https://github.com/opencurve/community/blob/master/GOVERNANCE.md):
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/15689619/211236417-eb405af2-7f0c-48b3-9012-cf41f5ab6bc7.png">

- [x] Wangpan
- [ ] ilixiaocui
- [x] Win93
- [x] wuhongsong
- [x] Cyber-SiKu

I'd also like to get a few LGTMs from the Core Committers too. (not necessary)

This PR will remain open for 6 days. 