### PR TITLE
promote montaguelhz as new committer of curve community

### DIFF
--- a/teams/Curve/team.json
+++ b/teams/Curve/team.json
@@ -19,6 +19,7 @@
         "Wine93",
         "fansehep",
         "Xinlong-Chen"
+        "montaguelhz"
     ],
     
     "reviewers": [


### PR DESCRIPTION
@montaguelhz has been a contributer since [May 11, 2023](https://github.com/opencurve/curve/pull/2465), and he has been very actively [contributing to Curve](https://github.com/opencurve/curve/pulls?q=is%3Apr+author%3Amontaguelhz) and [contributing to CurveAdm](https://github.com/opencurve/curveadm/pulls?q=is%3Apr+author%3Amontaguelhz) project.

So I'd like to promote @montaguelhz  to a Committer.

Needs explicit LGTM from @montaguelhz  and majority of the Curve Committers, according to [GOVERNANCE.md]
(https://github.com/opencurve/community/blob/master/GOVERNANCE.md):
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/15689619/211236417-eb405af2-7f0c-48b3-9012-cf41f5ab6bc7.png">

- [ ] Wangpan
- [ ] ilixiaocui
- [ ] cw123
- [ ] wuhongsong
- [ ] Cyber-SiKu

I'd also like to get a few LGTMs from the Core Committers too. (not necessary)

This PR will remain open for 6 days.